### PR TITLE
Use the idProperty from the map for non-populated associations

### DIFF
--- a/lib/doJoins.js
+++ b/lib/doJoins.js
@@ -40,9 +40,10 @@ module.exports = function doJoins(res, models, originalModel, modifiedModel) {
 
   // Simplify the collections that shouldnt be populated
   modifiedModel.collections.forEach(coll => {
+    const collFound = models.find(model => coll.mapId === model.mapId);
     if (!coll.populate) {
       joined = joined.map(nested => {
-        nested[coll.name] = nested[coll.name].map(c => c.id);
+        nested[coll.name] = nested[coll.name].map(c => c[collFound.idProperty]);
         return nested;
       });
     }


### PR DESCRIPTION
Using non-`id` primary keys caused non-populated associations to return `null`. This change uses the `idProperty` from the relation mapping object.