### PR TITLE
[PT-25] Improve API Response Times

### DIFF
--- a/lib/PreparedQuery.js
+++ b/lib/PreparedQuery.js
@@ -27,6 +27,7 @@ class PreparedQuery {
     this.knex = knex;
     this.modelId = modelId;
     this.populated = [];
+    this.ignored = [];
     this.whereClauses = [];
     this.shouldCalculateCount = false;
 
@@ -52,6 +53,27 @@ class PreparedQuery {
 
     if (allPopulateOptions.indexOf(name) === -1) {
       throw new Error(`Invalid populate param: ${name}`);
+    }
+
+    // Chainable
+    return this;
+  }
+
+  /**
+   * Ignore the selection and joins for a collection or association of the
+   * primary model of the query.
+   *
+   * @param {String} name - The name property of the association or collection
+   */
+  ignore(name) {
+    this.ignored.push(name);
+
+    const allIgnoredOptions =
+      this.originalModel.collections.map(a => a.name)
+      .concat(this.originalModel.associations.map(a => a.name));
+
+    if (allIgnoredOptions.indexOf(name) === -1) {
+      throw new Error(`Invalid ignore param: ${name}`);
     }
 
     // Chainable
@@ -208,11 +230,13 @@ class PreparedQuery {
 
       // Add a flag to determine which connections will need populating
       associations: this.originalModel.associations.map(assoc => {
-        assoc.populate = !!this.populated.find(name => name === assoc.name);
+        assoc.ignore = !!this.ignored.find(name => name === assoc.name);
+        assoc.populate = !!(this.populated.find(name => name === assoc.name) && !assoc.ignore);
         return assoc;
       }),
       collections: this.originalModel.collections.map(coll => {
-        coll.populate = !!this.populated.find(name => name === coll.name);
+        coll.ignore = !!this.ignored.find(name => name === coll.name);
+        coll.populate = !!(this.populated.find(name => name === coll.name) && !coll.ignore);
         return coll;
       })
     };

--- a/lib/constructQuery.js
+++ b/lib/constructQuery.js
@@ -1,5 +1,4 @@
 const helpers = require('./helpers');
-
 /**
  * Builds up a list of select statements for a collection of the entity being queried. This
  * includes the idProperty, any regular properties and any associations if this collection
@@ -10,6 +9,10 @@ function addCollectionSelects(coll, model, models) {
   const collModel = models.find(m => m.mapId === coll.mapId);
   if (!collModel) {
     throw new Error(`Invalid mapId: ${coll.mapId}`);
+  }
+
+  if (coll.ignore) {
+    return [];
   }
 
   let selects = collModel.properties.map(prop =>
@@ -36,6 +39,11 @@ function addCollectionSelects(coll, model, models) {
  * @ignore
  */
 function addAssociationSelects(assoc, model, models) {
+
+  if (assoc.ignore) {
+    return [];
+  }
+
   if (!assoc.populate) {
     // If an association is not populated, all we need is the regular column
     // in the table
@@ -236,7 +244,7 @@ function constructQuery(models, model, knex, whereClauses, sortAttr,
 
   // Generate a list of params to be passed to leftJoin
   const assocJoinParams = model.associations
-    .filter(assoc => assoc.populate)
+    .filter(assoc => assoc.populate && !assoc.ignore)
     .map(assoc => helpers.createAssociationJoinParameters(
       `${model.viewId}-core`,
       assoc.mapId,
@@ -245,7 +253,7 @@ function constructQuery(models, model, knex, whereClauses, sortAttr,
 
   // Generate joins for M-1 collections
   const collJoinParams = model.collections
-    .filter(coll => !coll.joinTable)
+    .filter(coll => !coll.joinTable && !coll.ignore)
     .map(coll => helpers.createCollectionJoinParameters(
       model.mapId,
       `${model.viewId}-core`,
@@ -254,7 +262,7 @@ function constructQuery(models, model, knex, whereClauses, sortAttr,
 
   // Generate joins for M-M collections with a join table
   const collJoinTableParams = model.collections
-    .filter(coll => coll.joinTable)
+    .filter(coll => coll.joinTable && !coll.ignore)
     .map(coll => [
       helpers.createCollectionJoinParameters(
         model.mapId,

--- a/test/constructQuery.test.js
+++ b/test/constructQuery.test.js
@@ -35,6 +35,19 @@ const models = [
     associations: [
       { name: 'tutor', mapId: 'tutor', viewId: 'tutor' }
     ],
+  },
+  {
+    mapId: 'human',
+    viewId: 'human_view',
+    idProperty: 'id',
+    properties: ['height', 'weight'],
+    collections: [
+      { name: 'friends', mapId: 'friend', viewId: 'friend', ignore: true }
+    ],
+    associations: [
+      { name: 'students', mapId: 'student', viewId: 'student', ignore: true },
+      { name: 'tutors', mapId: 'tutor', viewId: 'tutor', ignore: true }
+    ]
   }
 ];
 
@@ -82,6 +95,13 @@ describe('ConstructQuery', () => {
       ]);
     });
 
+    it('should return no selects if a collection is set to ignore true', () => {
+      const selects = constructQuery._addCollectionSelects(
+          models[3].collections[0], models[3], models);
+
+      expect(selects).toEqual([]);
+    });
+
   });
 
   describe('#addAssociationSelects', () => {
@@ -102,6 +122,13 @@ describe('ConstructQuery', () => {
         'tutor.email as tutor_email',
         'tutor.id as tutor_id'
       ]);
+    });
+
+    it('should return an empty select array when ignore is true', () => {
+      const selects = constructQuery._addAssociationSelects(
+        models[3].associations[0], models[3], models);
+
+      expect(selects).toEqual([]);
     });
 
   });

--- a/test/constructQuery.test.js
+++ b/test/constructQuery.test.js
@@ -42,11 +42,12 @@ const models = [
     idProperty: 'id',
     properties: ['height', 'weight'],
     collections: [
-      { name: 'friends', mapId: 'friend', viewId: 'friend', ignore: true }
+      { name: 'friends', mapId: 'friend', viewId: 'friend', populate: false, ignore: true },
+      { name: 'students', mapId: 'student', viewId: 'student', populate: true, ignore: false }
     ],
     associations: [
-      { name: 'students', mapId: 'student', viewId: 'student', ignore: true },
-      { name: 'tutors', mapId: 'tutor', viewId: 'tutor', ignore: true }
+      { name: 'students', mapId: 'student', viewId: 'student', populate: false, ignore: true },
+      { name: 'tutors', mapId: 'tutor', viewId: 'tutor', populate: false, ignore: false }
     ]
   }
 ];
@@ -102,6 +103,20 @@ describe('ConstructQuery', () => {
       expect(selects).toEqual([]);
     });
 
+    it(
+      'should select the associations of the selection when ignore false and populate true',
+    () => {
+      const selects = constructQuery._addCollectionSelects(
+          models[3].collections[1], models[3], models);
+
+      expect(selects).toEqual([
+        'student.name as student_name',
+        'student.email as student_email',
+        'student.id as student_id',
+        'student.tutor as student_tutor'
+      ]);
+    });
+
   });
 
   describe('#addAssociationSelects', () => {
@@ -129,6 +144,17 @@ describe('ConstructQuery', () => {
         models[3].associations[0], models[3], models);
 
       expect(selects).toEqual([]);
+    });
+
+    it(
+      'should only select the ID property on the core table when populate false and ignore false',
+    () => {
+      const selects = constructQuery._addAssociationSelects(
+        models[3].associations[1], models[3], models);
+
+      expect(selects).toEqual([
+        'human_view-core.tutor as tutor'
+      ]);
     });
 
   });


### PR DESCRIPTION
This PR:

- Allows you to set an ignore property on collections and associations so we don't have to grab the IDs for no reason.
- This is necessary as visions gets IDs for any association/collection by default

I've made this an additive change (i.e. adding a new property instead of changing the meaning of existing properties) so it doesn't affect anything relying on the existing behaviour.